### PR TITLE
Pass query args when pulling waiting tasks as well

### DIFF
--- a/taskw_ng/warrior.py
+++ b/taskw_ng/warrior.py
@@ -367,7 +367,7 @@ class TaskWarrior(TaskWarriorBase):
         # 'waiting' tasks are returned separately from 'pending' tasks
         # Here we merge the waiting list back into the pending list.
         if "pending" in results:
-            results["pending"].extend(self._get_task_objects("status:waiting", "export"))
+            results["pending"].extend(self._get_task_objects("status:waiting", query_args, "export"))
 
         return results
 


### PR DESCRIPTION
When trying out [syncall between task warrior and asana](https://github.com/bergercookie/syncall/blob/master/docs/readme-tw-asana.md) I had a bunch of private tasks synced, which were not tagged as `+asana`.

I discovered that these were all `waiting` tasks, and discovered that the `query_args` are not passed to the corresponding call in the `TaskWarrior` class.

Anways, thanks for the great work on this library.